### PR TITLE
max_total_wal_size

### DIFF
--- a/client/cli/src/config.rs
+++ b/client/cli/src/config.rs
@@ -198,6 +198,13 @@ pub trait CliConfiguration<DCV: DefaultConfigurationValues = ()>: Sized {
 		Ok(self.database_params().map(|x| x.database_cache_size()).unwrap_or_default())
 	}
 
+	/// Get the database max total wal size.
+	///
+	/// By default this is retrieved from `DatabaseParams` if it is available. Otherwise its `None`.
+	fn database_max_total_wal_size(&self) -> Result<Option<usize>> {
+		Ok(self.database_params().map(|x| x.database_max_total_wal_size()).unwrap_or_default())
+	}
+
 	/// Get the database backend variant.
 	///
 	/// By default this is retrieved from `DatabaseParams` if it is available. Otherwise its `None`.
@@ -210,6 +217,7 @@ pub trait CliConfiguration<DCV: DefaultConfigurationValues = ()>: Sized {
 		&self,
 		base_path: &PathBuf,
 		cache_size: usize,
+		max_total_wal_size: Option<usize>,
 		database: Database,
 		role: &Role,
 	) -> Result<DatabaseSource> {
@@ -220,7 +228,7 @@ pub trait CliConfiguration<DCV: DefaultConfigurationValues = ()>: Sized {
 		let rocksdb_path = base_path.join("db").join(role_dir);
 		let paritydb_path = base_path.join("paritydb").join(role_dir);
 		Ok(match database {
-			Database::RocksDb => DatabaseSource::RocksDb { path: rocksdb_path, cache_size },
+			Database::RocksDb => DatabaseSource::RocksDb { path: rocksdb_path, cache_size, max_total_wal_size },
 			Database::ParityDb => DatabaseSource::ParityDb { path: paritydb_path },
 			Database::ParityDbDeprecated => {
 				eprintln!(
@@ -229,7 +237,7 @@ pub trait CliConfiguration<DCV: DefaultConfigurationValues = ()>: Sized {
 				);
 				DatabaseSource::ParityDb { path: paritydb_path }
 			},
-			Database::Auto => DatabaseSource::Auto { paritydb_path, rocksdb_path, cache_size },
+			Database::Auto => DatabaseSource::Auto { paritydb_path, rocksdb_path, cache_size, max_total_wal_size },
 		})
 	}
 
@@ -485,6 +493,7 @@ pub trait CliConfiguration<DCV: DefaultConfigurationValues = ()>: Sized {
 		let net_config_dir = config_dir.join(DEFAULT_NETWORK_CONFIG_PATH);
 		let client_id = C::client_id();
 		let database_cache_size = self.database_cache_size()?.unwrap_or(1024);
+		let database_max_total_wal_size = self.database_max_total_wal_size();
 		let database = self.database()?.unwrap_or(Database::RocksDb);
 		let node_key = self.node_key(&net_config_dir)?;
 		let role = self.role(is_dev)?;
@@ -513,7 +522,7 @@ pub trait CliConfiguration<DCV: DefaultConfigurationValues = ()>: Sized {
 			)?,
 			keystore_remote,
 			keystore,
-			database: self.database_config(&config_dir, database_cache_size, database, &role)?,
+			database: self.database_config(&config_dir, database_cache_size, database_max_total_wal_size, database, &role)?,
 			state_cache_size: self.state_cache_size()?,
 			state_cache_child_ratio: self.state_cache_child_ratio()?,
 			state_pruning: self.state_pruning(unsafe_pruning, &role)?,

--- a/client/cli/src/config.rs
+++ b/client/cli/src/config.rs
@@ -217,7 +217,7 @@ pub trait CliConfiguration<DCV: DefaultConfigurationValues = ()>: Sized {
 		&self,
 		base_path: &PathBuf,
 		cache_size: usize,
-		max_total_wal_size: Option<usize>,
+		max_total_wal_size: usize,
 		database: Database,
 		role: &Role,
 	) -> Result<DatabaseSource> {
@@ -493,7 +493,7 @@ pub trait CliConfiguration<DCV: DefaultConfigurationValues = ()>: Sized {
 		let net_config_dir = config_dir.join(DEFAULT_NETWORK_CONFIG_PATH);
 		let client_id = C::client_id();
 		let database_cache_size = self.database_cache_size()?.unwrap_or(1024);
-		let database_max_total_wal_size = self.database_max_total_wal_size();
+		let database_max_total_wal_size = self.database_max_total_wal_size()?.unwrap_or(0);
 		let database = self.database()?.unwrap_or(Database::RocksDb);
 		let node_key = self.node_key(&net_config_dir)?;
 		let role = self.role(is_dev)?;

--- a/client/cli/src/params/database_params.rs
+++ b/client/cli/src/params/database_params.rs
@@ -35,6 +35,10 @@ pub struct DatabaseParams {
 	/// Limit the memory the database cache can use.
 	#[clap(long = "db-cache", value_name = "MiB")]
 	pub database_cache_size: Option<usize>,
+
+	/// Limit the total storage capacity that the database can use for WAL files.
+	#[clap(long = "db-max-total-wal-size", value_name = "MiB")]
+	pub database_max_total_wal_size: Option<usize>,
 }
 
 impl DatabaseParams {
@@ -46,5 +50,10 @@ impl DatabaseParams {
 	/// Limit the memory the database cache can use.
 	pub fn database_cache_size(&self) -> Option<usize> {
 		self.database_cache_size
+	}
+
+	/// Limit the total storage capacity that the database can use for WAL files.
+	pub fn database_max_total_wal_size(&self) -> Option<usize> {
+		self.database_max_total_wal_size
 	}
 }

--- a/client/db/src/lib.rs
+++ b/client/db/src/lib.rs
@@ -325,6 +325,8 @@ pub enum DatabaseSource {
 		rocksdb_path: PathBuf,
 		/// Cache size in MiB. Used only by `RocksDb` variant of `DatabaseSource`.
 		cache_size: usize,
+		/// Max total WAL size in MiB. Used only by `RocksDb` variant of `DatabaseSource`.
+		max_total_wal_size: Option(usize),
 	},
 	/// Load a RocksDB database from a given path. Recommended for most uses.
 	RocksDb {
@@ -332,6 +334,8 @@ pub enum DatabaseSource {
 		path: PathBuf,
 		/// Cache size in MiB.
 		cache_size: usize,
+		/// Max total WAL size in MiB.
+		max_total_wal_size: Option(usize),
 	},
 
 	/// Load a ParityDb database from a given path.

--- a/client/db/src/lib.rs
+++ b/client/db/src/lib.rs
@@ -326,7 +326,7 @@ pub enum DatabaseSource {
 		/// Cache size in MiB. Used only by `RocksDb` variant of `DatabaseSource`.
 		cache_size: usize,
 		/// Max total WAL size in MiB. Used only by `RocksDb` variant of `DatabaseSource`.
-		max_total_wal_size: Option(usize),
+		max_total_wal_size: usize,
 	},
 	/// Load a RocksDB database from a given path. Recommended for most uses.
 	RocksDb {
@@ -335,7 +335,7 @@ pub enum DatabaseSource {
 		/// Cache size in MiB.
 		cache_size: usize,
 		/// Max total WAL size in MiB.
-		max_total_wal_size: Option(usize),
+		max_total_wal_size: usize,
 	},
 
 	/// Load a ParityDb database from a given path.

--- a/client/db/src/utils.rs
+++ b/client/db/src/utils.rs
@@ -203,11 +203,11 @@ fn open_database_at<Block: BlockT>(
 	let db: Arc<dyn Database<DbHash>> = match &source {
 		DatabaseSource::ParityDb { path } => open_parity_db::<Block>(path, db_type, true)?,
 		DatabaseSource::RocksDb { path, cache_size, max_total_wal_size } =>
-			open_kvdb_rocksdb::<Block>(path, db_type, true, *cache_size, *max_total_wal_size)?,
+			open_kvdb_rocksdb::<Block>(path, db_type, true, *cache_size, max_total_wal_size)?,
 		DatabaseSource::Custom(db) => db.clone(),
 		DatabaseSource::Auto { paritydb_path, rocksdb_path, cache_size, max_total_wal_size } => {
 			// check if rocksdb exists first, if not, open paritydb
-			match open_kvdb_rocksdb::<Block>(rocksdb_path, db_type, false, *cache_size, *max_total_wal_size) {
+			match open_kvdb_rocksdb::<Block>(rocksdb_path, db_type, false, *cache_size, max_total_wal_size) {
 				Ok(db) => db,
 				Err(OpenDbError::NotEnabled(_)) | Err(OpenDbError::DoesNotExist) =>
 					open_parity_db::<Block>(paritydb_path, db_type, true)?,

--- a/client/db/src/utils.rs
+++ b/client/db/src/utils.rs
@@ -202,12 +202,12 @@ fn open_database_at<Block: BlockT>(
 ) -> sp_blockchain::Result<Arc<dyn Database<DbHash>>> {
 	let db: Arc<dyn Database<DbHash>> = match &source {
 		DatabaseSource::ParityDb { path } => open_parity_db::<Block>(path, db_type, true)?,
-		DatabaseSource::RocksDb { path, cache_size } =>
-			open_kvdb_rocksdb::<Block>(path, db_type, true, *cache_size)?,
+		DatabaseSource::RocksDb { path, cache_size, max_total_wal_size } =>
+			open_kvdb_rocksdb::<Block>(path, db_type, true, *cache_size, *max_total_wal_size)?,
 		DatabaseSource::Custom(db) => db.clone(),
-		DatabaseSource::Auto { paritydb_path, rocksdb_path, cache_size } => {
+		DatabaseSource::Auto { paritydb_path, rocksdb_path, cache_size, max_total_wal_size } => {
 			// check if rocksdb exists first, if not, open paritydb
-			match open_kvdb_rocksdb::<Block>(rocksdb_path, db_type, false, *cache_size) {
+			match open_kvdb_rocksdb::<Block>(rocksdb_path, db_type, false, *cache_size, *max_total_wal_size) {
 				Ok(db) => db,
 				Err(OpenDbError::NotEnabled(_)) | Err(OpenDbError::DoesNotExist) =>
 					open_parity_db::<Block>(paritydb_path, db_type, true)?,
@@ -298,6 +298,7 @@ fn open_kvdb_rocksdb<Block: BlockT>(
 	db_type: DatabaseType,
 	create: bool,
 	cache_size: usize,
+	max_total_wal_size: Option<usize>,
 ) -> OpenDbResult {
 	// first upgrade database to required version
 	match crate::upgrade::upgrade_db::<Block>(path, db_type) {
@@ -310,7 +311,10 @@ fn open_kvdb_rocksdb<Block: BlockT>(
 	// and now open database assuming that it has the latest version
 	let mut db_config = kvdb_rocksdb::DatabaseConfig::with_columns(NUM_COLUMNS);
 	db_config.create_if_missing = create;
-	db_config.max_total_wal_size = Some(5u64 << 33); // 40 GB
+	db_config.max_total_wal_size = match max_total_wal_size {
+		Some(size) => size as u64 << 20;
+		None => None,
+	};
 
 	let mut memory_budget = std::collections::HashMap::new();
 	match db_type {
@@ -349,6 +353,7 @@ fn open_kvdb_rocksdb<Block: BlockT>(
 	_db_type: DatabaseType,
 	_create: bool,
 	_cache_size: usize,
+	_max_total_wal_size: Option<usize>,
 ) -> OpenDbResult {
 	Err(OpenDbError::NotEnabled("with-kvdb-rocksdb"))
 }

--- a/client/db/src/utils.rs
+++ b/client/db/src/utils.rs
@@ -310,6 +310,7 @@ fn open_kvdb_rocksdb<Block: BlockT>(
 	// and now open database assuming that it has the latest version
 	let mut db_config = kvdb_rocksdb::DatabaseConfig::with_columns(NUM_COLUMNS);
 	db_config.create_if_missing = create;
+	db_config.max_total_wal_size = Some(5u64 << 33); // 40 GB
 
 	let mut memory_budget = std::collections::HashMap::new();
 	match db_type {


### PR DESCRIPTION
adds cli flag `--db-max-total-wal-size` to allow specifying `db_config.max_total_wal_size`

https://docs.rs/kvdb-rocksdb/latest/kvdb_rocksdb/struct.DatabaseConfig.html#structfield.max_total_wal_size
https://github.com/facebook/rocksdb/blob/534fb06dd38234a2d6234d17366a7b0ac5272f48/include/rocksdb/options.h#L612

```
Once write-ahead logs exceed this size, we will start forcing the flush of
column families whose memtables are backed by the oldest live WAL file
(i.e. the ones that are causing all the space amplification).
```