### PR TITLE
Add new functions to the `PolymeshHook` trait 

### DIFF
--- a/frame/contracts/src/benchmarking/mod.rs
+++ b/frame/contracts/src/benchmarking/mod.rs
@@ -209,6 +209,9 @@ benchmarks! {
 		let k in 0..1024;
 		let instance = Contract::<T>::with_storage(WasmModule::dummy(), k, T::Schedule::get().limits.payload_len)?;
 		instance.info()?.queue_trie_for_deletion()?;
+		// Required for linking the contract to a did
+		let cdd_origin = T::PolymeshHooks::get_cdd_provider_origin();
+		T::PolymeshHooks::register_did_with_cdd(cdd_origin, instance.caller.clone())?;
 	}: {
 		ContractInfo::<T>::process_deletion_queue_batch(Weight::MAX)
 	}

--- a/frame/contracts/src/benchmarking/mod.rs
+++ b/frame/contracts/src/benchmarking/mod.rs
@@ -89,6 +89,10 @@ where
 		let salt = vec![0xff];
 		let addr = Contracts::<T>::contract_address(&caller, &module.hash, &data, &salt);
 
+		// Required for linking the contract to a did
+		let cdd_origin = T::PolymeshHooks::get_cdd_provider_origin();
+		T::PolymeshHooks::register_did_with_cdd(cdd_origin, caller.clone())?;
+
 		Contracts::<T>::store_code_raw(module.code, caller.clone())?;
 		Contracts::<T>::instantiate(
 			RawOrigin::Signed(caller.clone()).into(),
@@ -209,9 +213,6 @@ benchmarks! {
 		let k in 0..1024;
 		let instance = Contract::<T>::with_storage(WasmModule::dummy(), k, T::Schedule::get().limits.payload_len)?;
 		instance.info()?.queue_trie_for_deletion()?;
-		// Required for linking the contract to a did
-		let cdd_origin = T::PolymeshHooks::get_cdd_provider_origin();
-		T::PolymeshHooks::register_did_with_cdd(cdd_origin, instance.caller.clone())?;
 	}: {
 		ContractInfo::<T>::process_deletion_queue_batch(Weight::MAX)
 	}

--- a/frame/contracts/src/benchmarking/mod.rs
+++ b/frame/contracts/src/benchmarking/mod.rs
@@ -283,7 +283,12 @@ benchmarks! {
 		let input = vec![42u8; i as usize];
 		let salt = vec![42u8; s as usize];
 		let value = Pallet::<T>::min_balance();
-		let caller = whitelisted_caller();
+		let caller: T::AccountId = whitelisted_caller();
+
+		// Required for linking the contract to a did
+		let cdd_origin = T::PolymeshHooks::get_cdd_provider_origin();
+		T::PolymeshHooks::register_did_with_cdd(cdd_origin, caller.clone())?;
+
 		T::Currency::make_free_balance_be(&caller, caller_funding::<T>());
 		let WasmModule { code, hash, .. } = WasmModule::<T>::sized(c, Location::Call);
 		let origin = RawOrigin::Signed(caller.clone());
@@ -312,7 +317,12 @@ benchmarks! {
 		let input = vec![42u8; i as usize];
 		let salt = vec![42u8; s as usize];
 		let value = Pallet::<T>::min_balance();
-		let caller = whitelisted_caller();
+		let caller: T::AccountId = whitelisted_caller();
+
+		// Required for linking the contract to a did
+		let cdd_origin = T::PolymeshHooks::get_cdd_provider_origin();
+		T::PolymeshHooks::register_did_with_cdd(cdd_origin, caller.clone())?;
+
 		T::Currency::make_free_balance_be(&caller, caller_funding::<T>());
 		let WasmModule { code, hash, .. } = WasmModule::<T>::dummy();
 		let origin = RawOrigin::Signed(caller.clone());
@@ -375,7 +385,12 @@ benchmarks! {
 	#[pov_mode = Measured]
 	upload_code {
 		let c in 0 .. Perbill::from_percent(49).mul_ceil(T::MaxCodeLen::get());
-		let caller = whitelisted_caller();
+		let caller: T::AccountId = whitelisted_caller();
+
+		// Required for linking the contract to a did
+		let cdd_origin = T::PolymeshHooks::get_cdd_provider_origin();
+		T::PolymeshHooks::register_did_with_cdd(cdd_origin, caller.clone())?;
+
 		T::Currency::make_free_balance_be(&caller, caller_funding::<T>());
 		let WasmModule { code, hash, .. } = WasmModule::<T>::sized(c, Location::Call);
 		let origin = RawOrigin::Signed(caller.clone());
@@ -391,7 +406,12 @@ benchmarks! {
 	// item (`OwnerInfoOf`).
 	#[pov_mode = Measured]
 	remove_code {
-		let caller = whitelisted_caller();
+		let caller: T::AccountId = whitelisted_caller();
+
+		// Required for linking the contract to a did
+		let cdd_origin = T::PolymeshHooks::get_cdd_provider_origin();
+		T::PolymeshHooks::register_did_with_cdd(cdd_origin, caller.clone())?;
+
 		T::Currency::make_free_balance_be(&caller, caller_funding::<T>());
 		let WasmModule { code, hash, .. } = WasmModule::<T>::dummy();
 		let origin = RawOrigin::Signed(caller.clone());
@@ -770,6 +790,11 @@ benchmarks! {
 	seal_terminate {
 		let r in 0 .. 1;
 		let beneficiary = account::<T::AccountId>("beneficiary", 0, 0);
+
+		// Required for linking the beneficiary to a cdd
+		let cdd_origin = T::PolymeshHooks::get_cdd_provider_origin();
+		T::PolymeshHooks::register_did_with_cdd(cdd_origin, beneficiary.clone())?;
+
 		let beneficiary_bytes = beneficiary.encode();
 		let beneficiary_len = beneficiary_bytes.len();
 		let code = WasmModule::<T>::from(ModuleDefinition {
@@ -1560,7 +1585,13 @@ benchmarks! {
 	seal_transfer {
 		let r in 0 .. API_BENCHMARK_BATCHES;
 		let accounts = (0..r * API_BENCHMARK_BATCH_SIZE)
-			.map(|i| account::<T::AccountId>("receiver", i, 0))
+			.map(|i| {
+				let account_id = account::<T::AccountId>("receiver", i, 0);
+				// Required for linking the receiver to a cdd
+				let cdd_origin = T::PolymeshHooks::get_cdd_provider_origin();
+				T::PolymeshHooks::register_did_with_cdd(cdd_origin, account_id.clone()).unwrap();
+				account_id
+			})
 			.collect::<Vec<_>>();
 		let account_len = accounts.get(0).map(|i| i.encode().len()).unwrap_or(0);
 		let account_bytes = accounts.iter().flat_map(|x| x.encode()).collect();

--- a/frame/contracts/src/lib.rs
+++ b/frame/contracts/src/lib.rs
@@ -175,7 +175,7 @@ pub trait PolymeshHooks<T: frame_system::Config> {
 
 	#[cfg(feature = "runtime-benchmarks")]
 	fn register_did_with_cdd(
-		cdd_provider_origin: Option<T::RuntimeOrigin>, 
+		cdd_provider_origin: Option<T::RuntimeOrigin>,
 		account: T::AccountId
 	) -> frame_support::dispatch::DispatchResult;
 }
@@ -205,7 +205,7 @@ impl<T: frame_system::Config> PolymeshHooks<T> for DefaultPolymeshHooks {
 
 	#[cfg(feature = "runtime-benchmarks")]
 	fn register_did_with_cdd(
-		_cdd_provider_origin: Option<T::RuntimeOrigin>, 
+		_cdd_provider_origin: Option<T::RuntimeOrigin>,
 		_account: T::AccountId
 	) -> frame_support::dispatch::DispatchResult {
 		Ok(())

--- a/frame/contracts/src/lib.rs
+++ b/frame/contracts/src/lib.rs
@@ -169,6 +169,15 @@ pub trait PolymeshHooks<T: frame_system::Config> {
 		caller: &T::AccountId,
 		contract: &T::AccountId,
 	) -> frame_support::dispatch::DispatchResult;
+
+	#[cfg(feature = "runtime-benchmarks")]
+	fn get_cdd_provider_origin() -> Option<T::RuntimeOrigin>;
+
+	#[cfg(feature = "runtime-benchmarks")]
+	fn register_did_with_cdd(
+		cdd_provider_origin: Option<T::RuntimeOrigin>, 
+		account: T::AccountId
+	) -> frame_support::dispatch::DispatchResult;
 }
 
 /// Default Polymesh hooks.
@@ -185,6 +194,19 @@ impl<T: frame_system::Config> PolymeshHooks<T> for DefaultPolymeshHooks {
 	fn on_instantiate_transfer(
 		_caller: &T::AccountId,
 		_contract: &T::AccountId,
+	) -> frame_support::dispatch::DispatchResult {
+		Ok(())
+	}
+
+	#[cfg(feature = "runtime-benchmarks")]
+	fn get_cdd_provider_origin() -> Option<T::RuntimeOrigin> {
+		None
+	}
+
+	#[cfg(feature = "runtime-benchmarks")]
+	fn register_did_with_cdd(
+		_cdd_provider_origin: Option<T::RuntimeOrigin>, 
+		_account: T::AccountId
 	) -> frame_support::dispatch::DispatchResult {
 		Ok(())
 	}


### PR DESCRIPTION
Adds two new functions to the `PolymeshHook` trait. This allows executing the benchmarks with our runtime. 
